### PR TITLE
fix: update tagged logger to work with ruby 3

### DIFF
--- a/lib/sensible_logging/middlewares/tagged_logger.rb
+++ b/lib/sensible_logging/middlewares/tagged_logger.rb
@@ -6,22 +6,26 @@ require_relative '../helpers/subdomain_parser'
 
 # Allow custom tags to be captured
 class TaggedLogger
-  def initialize( # rubocop:disable Metrics/ParameterLists
+  def initialize( # rubocop:disable Metrics/MethodLength
     app,
-    logger: Logger.new($stdout),
-    tags: [],
-    use_default_tags: true,
-    tld_length: 1,
-    include_log_severity: true
+    options = {}
   )
     @app = app
 
-    logger = setup_severity_tag(logger) if include_log_severity
+    options = {
+      logger: Logger.new($stdout),
+      tags: [],
+      use_default_tags: true,
+      tld_length: 1,
+      include_log_severity: true
+    }.merge(options)
 
-    @logger = ActiveSupport::TaggedLogging.new(logger)
+    options[:logger] = setup_severity_tag(options[:logger]) if options[:include_log_severity]
+
+    @logger = ActiveSupport::TaggedLogging.new(options[:logger])
     @tags = []
-    @tags += default_tags(tld_length: tld_length) if use_default_tags
-    @tags += tags
+    @tags += default_tags(tld_length: options[:tld_length]) if options[:use_default_tags]
+    @tags += options[:tags]
   end
 
   def call(env)

--- a/spec/integration/sensible_logger_spec.rb
+++ b/spec/integration/sensible_logger_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rack/mock'
+require 'sinatra/base'
+
+class App < Sinatra::Base
+  register Sinatra::SensibleLogging
+
+  configure do
+    set :log_level, Logger::DEBUG
+  end
+
+  sensible_logging(
+    logger: Logger.new(IO::NULL),
+    log_tags: [->(req) { [req.port] }],
+    exclude_params: ['two']
+  )
+
+  get '/hello' do
+    logger.tagged('todo') do |logger|
+      logger.debug('test')
+      env['rack.errors'].puts('This is an example error')
+    end
+    'test'
+  end
+end
+
+describe 'Sensible Logging integrated with Sinatra' do # rubocop:disable RSpec/DescribeClass
+  it 'request returns 200' do
+    env = Rack::MockRequest.env_for('http://www.blah.google.co.uk/hello')
+
+    app = App.new
+    response = app.call(env)
+
+    expect(response[0]).to eq(200)
+  end
+end

--- a/spec/rack/common_logger_spec.rb
+++ b/spec/rack/common_logger_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class MyApp
+  def call(env); end
+end
+
+describe Rack::CommonLogger do
+  it 'disables common logger by default' do
+    logger = instance_double('MyLogger', write: false)
+
+    common_logger = described_class.new(MyApp.new, logger)
+
+    common_logger.call({})
+
+    expect(logger).not_to have_received(:write)
+  end
+end

--- a/spec/sensible_logging_spec.rb
+++ b/spec/sensible_logging_spec.rb
@@ -1,24 +1,7 @@
 # frozen_string_literal: true
 
-class MyApp
-  def call(env)
-  end
-end
-
 describe SensibleLogging do
   it 'has a version number' do
     expect(SensibleLogging::VERSION).not_to be nil
-  end
-end
-
-describe Rack::CommonLogger do
-  it 'disables common logger by default' do
-    logger = instance_double('MyLogger', write: false)
-
-    common_logger = Rack::CommonLogger.new(MyApp.new, logger)
-
-    common_logger.call({})
-
-    expect(logger).to_not have_received(:write)
   end
 end

--- a/spec/sensible_logging_spec.rb
+++ b/spec/sensible_logging_spec.rb
@@ -1,7 +1,24 @@
 # frozen_string_literal: true
 
+class MyApp
+  def call(env)
+  end
+end
+
 describe SensibleLogging do
   it 'has a version number' do
     expect(SensibleLogging::VERSION).not_to be nil
+  end
+end
+
+describe Rack::CommonLogger do
+  it 'disables common logger by default' do
+    logger = instance_double('MyLogger', write: false)
+
+    common_logger = Rack::CommonLogger.new(MyApp.new, logger)
+
+    common_logger.call({})
+
+    expect(logger).to_not have_received(:write)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 require 'simplecov'
 
+require_relative '../lib/sensible_logging'
 require_relative '../lib/sensible_logging/version'
 require_relative '../lib/sensible_logging/middlewares/request_id'
 require_relative '../lib/sensible_logging/middlewares/request_logger'


### PR DESCRIPTION
Rack doesn't call the keyword arguments in the new Ruby 3 style, so it will not auto-convert the hash to keyword arguments. Have updated tagged logger to take an options hash instead to make this compatible.