### PR TITLE
fix: rescue Rack::Multipart::MultipartPartLimitError and let Sinatra handle it.

### DIFF
--- a/lib/sensible_logging/middlewares/request_logger.rb
+++ b/lib/sensible_logging/middlewares/request_logger.rb
@@ -28,5 +28,9 @@ class RequestLogger
 
   def filter_params(req)
     req.params.reject { |x| @filtered_params.include?(x) }
+  rescue Rack::Multipart::MultipartPartLimitError
+    # Let Sinatra handle multipart limit error.
+    # Don't log the params because we don't have them in this case.
+    {}
   end
 end

--- a/spec/integration/sensible_logger_spec.rb
+++ b/spec/integration/sensible_logger_spec.rb
@@ -28,10 +28,53 @@ end
 describe 'Sensible Logging integrated with Sinatra' do # rubocop:disable RSpec/DescribeClass
   it 'request returns 200' do
     env = Rack::MockRequest.env_for('http://www.blah.google.co.uk/hello')
-
     app = App.new
+
     response = app.call(env)
 
     expect(response[0]).to eq(200)
+  end
+
+  context 'request_logger encountering multipart error' do
+    let(:env) do
+      data = invalid_multipart_body
+      env = Rack::MockRequest.env_for('http://www.blah.google.co.uk/hello', {
+        'CONTENT_TYPE' => 'multipart/form-data; boundary=myboundary',
+        'CONTENT_LENGTH' => data.bytesize,
+        input: StringIO.new(data)
+      })
+    end
+
+    it 'does not rescue error when show_exceptions is enabled' do
+      klass = Class.new(App) do
+        configure { set :show_exceptions, true }
+        error(Rack::Multipart::MultipartPartLimitError) do
+          halt(413, "You've exceeded the multipart part limit.")
+        end
+      end
+      app = klass.new
+
+      err = begin
+        app.call(env)
+      rescue => e
+        err = e
+      end
+
+      expect(err.class).to be(Rack::Multipart::MultipartPartLimitError)
+    end
+
+    it 'does rescue error when show_exceptions is disabled' do
+      klass = Class.new(App) do
+        configure { set :show_exceptions, false }
+        error(Rack::Multipart::MultipartPartLimitError) do
+          halt(413, "You've exceeded the multipart part limit.")
+        end
+      end
+      app = klass.new
+
+      response = app.call(env)
+
+      expect(response[0]).to eq(413)
+    end
   end
 end

--- a/spec/middlewares/request_logger_spec.rb
+++ b/spec/middlewares/request_logger_spec.rb
@@ -54,13 +54,13 @@ describe RequestLogger do
     expect(logger).to have_received(:info).with('method=POST path=/test client=n/a status=200 duration=1.0')
   end
 
-  it 'rescues and logs the request with no params if Rack::Multipart::MultipartPartLimitError is raised' do
+  it 'rescues request with no params if Rack::Multipart::MultipartPartLimitError is raised' do # rubocop:disable RSpec/ExampleLength
     data = invalid_multipart_body
     env = Rack::MockRequest.env_for('http://localhost/test', {
-                                'CONTENT_TYPE' => 'multipart/form-data; boundary=myboundary',
-                                'CONTENT_LENGTH' => data.bytesize,
-                                input: StringIO.new(data)
-                              })
+                                      'CONTENT_TYPE' => 'multipart/form-data; boundary=myboundary',
+                                      'CONTENT_LENGTH' => data.bytesize,
+                                      input: StringIO.new(data)
+                                    })
     env['logger'] = logger
     described_class.new(app).call(env)
 

--- a/spec/middlewares/request_logger_spec.rb
+++ b/spec/middlewares/request_logger_spec.rb
@@ -7,7 +7,10 @@ describe RequestLogger do
   let(:logger) { instance_double(Logger) }
 
   before do
-    allow(Time).to receive(:now).and_return(1, 2)
+    allow(Time).to receive(:now).and_return(
+      Time.new(2022, 12, 19, 0, 0, 0),
+      Time.new(2022, 12, 19, 0, 0, 1)
+    )
     allow(logger).to receive(:info)
   end
 
@@ -21,7 +24,7 @@ describe RequestLogger do
 
     described_class.new(app).call(env)
 
-    expect(logger).to have_received(:info).with('method=GET path=/test client=n/a status=200 duration=1')
+    expect(logger).to have_received(:info).with('method=GET path=/test client=n/a status=200 duration=1.0')
   end
 
   it 'logs the request with REMOTE_ADDR' do
@@ -30,7 +33,7 @@ describe RequestLogger do
 
     described_class.new(app).call(env)
 
-    expect(logger).to have_received(:info).with('method=GET path=/test client=123.456.789.123 status=200 duration=1')
+    expect(logger).to have_received(:info).with('method=GET path=/test client=123.456.789.123 status=200 duration=1.0')
   end
 
   it 'logs the request with X_FORWARDED_FOR' do
@@ -39,7 +42,7 @@ describe RequestLogger do
 
     described_class.new(app).call(env)
 
-    expect(logger).to have_received(:info).with('method=GET path=/test client=123.456.789.123 status=200 duration=1')
+    expect(logger).to have_received(:info).with('method=GET path=/test client=123.456.789.123 status=200 duration=1.0')
   end
 
   it 'logs the request with no params if not GET' do
@@ -48,6 +51,30 @@ describe RequestLogger do
 
     described_class.new(app).call(env)
 
-    expect(logger).to have_received(:info).with('method=POST path=/test client=n/a status=200 duration=1')
+    expect(logger).to have_received(:info).with('method=POST path=/test client=n/a status=200 duration=1.0')
+  end
+
+  it 'rescues and logs the request with no params if Rack::Multipart::MultipartPartLimitError is raised' do
+    env = multipart_part_limit_request
+    env['logger'] = logger
+    described_class.new(app).call(env)
+
+    expect(logger).to have_received(:info).with('method=GET path=/test client=n/a status=200 duration=1.0')
+  end
+
+  def multipart_part_limit_request
+    # rubocop:disable Style/StringConcatenation
+    # rubocop:disable Layout/LineLength
+    data = Rack::Utils.multipart_part_limit.times.map do
+      "--myboundary\r\ncontent-type: text/plain\r\ncontent-disposition: attachment; name=#{SecureRandom.hex(10)}; filename=#{SecureRandom.hex(10)}\r\n\r\ncontents\r\n"
+    end.join("\r\n") + "--myboundary--\r"
+    # rubocop:enable Layout/LineLength
+    # rubocop:enable Style/StringConcatenation
+
+    Rack::MockRequest.env_for('http://localhost/test', {
+                                'CONTENT_TYPE' => 'multipart/form-data; boundary=myboundary',
+                                'CONTENT_LENGTH' => data.bytesize,
+                                input: StringIO.new(data)
+                              })
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,3 +10,14 @@ require_relative '../lib/sensible_logging/middlewares/tagged_logger'
 require_relative '../lib/sensible_logging/helpers/subdomain_parser'
 
 ENV['RACK_ENV'] = 'test'
+
+# A multipart form that exceeds rack's multipart form limit.
+def invalid_multipart_body
+  # rubocop:disable Style/StringConcatenation
+  # rubocop:disable Layout/LineLength
+  Rack::Utils.multipart_part_limit.times.map do
+    "--myboundary\r\ncontent-type: text/plain\r\ncontent-disposition: attachment; name=#{SecureRandom.hex(10)}; filename=#{SecureRandom.hex(10)}\r\n\r\ncontents\r\n"
+  end.join("\r\n") + "--myboundary--\r"
+  # rubocop:enable Layout/LineLength
+  # rubocop:enable Style/StringConcatenation
+end


### PR DESCRIPTION
Hi, thanks for creating this gem! Sinatra logging has always been tough.

I have a rescue in my Sinatra app that rescues rack's error when you exceed its 128-open-file limit:

```
error(Rack::Multipart::MultipartPartLimitError) do
  halt(413, "Payload too large")
end
```

But this broke after installing the gem, and returned the natural 500 error instead (which prevents the RequestId middleware from adding the id to the header as well)

This happens because `req.params` is accessed in RequestLogger, which receives the exception and short-circuits the request from reaching the Sinatra app.

I propose catching this error and letting Sinatra handle it instead, inside RequestLogger.